### PR TITLE
Edited create_package.py to include a line changing the permissions of /...

### DIFF
--- a/CreateUserPkg/create_package.py
+++ b/CreateUserPkg/create_package.py
@@ -82,6 +82,7 @@ PlistArrayAdd "$3/private/var/db/dslocal/nodes/Default/groups/admin.plist" users
 
 PI_ENABLE_AUTOLOGIN = """
 /usr/bin/defaults write "$3/Library/Preferences/com.apple.loginwindow" autoLoginUser "_USERNAME_"
+/bin/chmod 644 "$3/Library/Preferences/com.apple.loginwindow.plist"
 """
 
 PI_LIVE_KILLDS = """


### PR DESCRIPTION
Edited create_package.py to change /Library/Preferences/com.apple.loginwindow.plist back to 0644.

Fixes an issue when installing on a non-booted sytsem (instadmg) where the permissions get changed to 0600.
